### PR TITLE
add support for SERVER_SHUTDOWN_ANNOUNCE_DELAY container env var

### DIFF
--- a/cf.yml
+++ b/cf.yml
@@ -14,6 +14,13 @@ Parameters:
       - Running
       - Stopped
 
+  ServerShutdownAnnounceDelay:
+    Type: Number
+    Description: Number of seconds (0-60) to wait between announcing that the server will be shut down and actual shutdown. Defaults to 30; set to 0 to disable (STOP_SERVER_ANNOUNCE_DELAY)
+    Default: 30
+    MinValue: 0
+    MaxValue: 60
+
   InstanceType:
     Type: String
     Description: "t3.medium is a good cost effective instance, 1 VCPU and 3.75 GB of RAM with moderate network performance. Change at your discretion. https://aws.amazon.com/ec2/instance-types/."
@@ -195,6 +202,7 @@ Metadata:
           - LevelType
           - EnableRollingLogs
           - Timezone
+          - ServerShutdownAnnounceDelay
       - Label:
           default: Optional Remote Access (SSH) Configuration
         Parameters:
@@ -251,6 +259,8 @@ Metadata:
         default: "Whether to enable rolling logs"
       Timezone:
         default: "The server's timezone"
+      ServerShutdownAnnounceDelay:
+        default: "Server shutdown warning"
 
 Conditions:
   MinecraftTypeTagProvided: !Not [!Equals [!Ref MinecraftTypeTag, ""]]
@@ -692,6 +702,8 @@ Resources:
               - Name: "TZ"
                 Value: !Sub "${Timezone}"
               - !Ref "AWS::NoValue"
+            - Name: "STOP_SERVER_ANNOUNCE_DELAY"
+              Value: !Sub "${ServerShutdownAnnounceDelay}"
 
   # ====================================================
   # SET DNS RECORD

--- a/cf.yml
+++ b/cf.yml
@@ -618,6 +618,7 @@ Resources:
         - Name: minecraft
           MemoryReservation: 1024
           Image: !Sub "itzg/minecraft-server:${MinecraftImageTag}"
+          StopTimeout: 100 # seconds; defaults to 30. Overrides ECS_CONTAINER_STOP_TIMEOUT in ECS agent config
           PortMappings:
             - ContainerPort: 25565
               HostPort: 25565


### PR DESCRIPTION
see https://github.com/itzg/docker-minecraft-server#server-shutdown-options

Defaults to 30, range bounded to 0-60 (0 to disable)